### PR TITLE
Update `VAnchor` in order to follow `LinkableAnchor` interface

### DIFF
--- a/contracts/anchor/src/contract.rs
+++ b/contracts/anchor/src/contract.rs
@@ -14,15 +14,16 @@ use crate::state::{
 use codec::Encode;
 use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg};
 use protocol_cosmwasm::anchor::{
-    ConfigResponse, Cw20HookMsg, EdgeInfoResponse, ExecuteMsg, InstantiateMsg,
-    MerkleRootInfoResponse, MerkleTreeInfoResponse, MigrateMsg, NeighborRootInfoResponse, QueryMsg,
-    WithdrawMsg,
+    ConfigResponse, Cw20HookMsg, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg, WithdrawMsg,
 };
 use protocol_cosmwasm::anchor_verifier::AnchorVerifier;
 use protocol_cosmwasm::error::ContractError;
 use protocol_cosmwasm::keccak::Keccak256;
 use protocol_cosmwasm::poseidon::Poseidon;
-use protocol_cosmwasm::structs::{Edge, COSMOS_CHAIN_TYPE, HISTORY_LENGTH};
+use protocol_cosmwasm::structs::{
+    Edge, EdgeInfoResponse, MerkleRootInfoResponse, MerkleTreeInfoResponse,
+    NeighborRootInfoResponse, COSMOS_CHAIN_TYPE, HISTORY_LENGTH,
+};
 use protocol_cosmwasm::token_wrapper::{
     ConfigResponse as TokenWrapperConfigResp, Cw20HookMsg as TokenWrapperHookMsg,
     ExecuteMsg as TokenWrapperExecuteMsg, GetAmountToWrapResponse,

--- a/contracts/vanchor/src/contract.rs
+++ b/contracts/vanchor/src/contract.rs
@@ -16,7 +16,7 @@ use protocol_cosmwasm::token_wrapper::{
     ConfigResponse as TokenWrapperConfigResp, Cw20HookMsg as TokenWrapperHookMsg,
     ExecuteMsg as TokenWrapperExecuteMsg, QueryMsg as TokenWrapperQueryMsg,
 };
-use protocol_cosmwasm::utils::{compute_chain_id_type, element_encoder, parse_string_to_uint128};
+use protocol_cosmwasm::utils::{compute_chain_id_type, element_encoder};
 use protocol_cosmwasm::vanchor::{
     Cw20HookMsg, ExecuteMsg, ExtData, InstantiateMsg, ProofData, QueryMsg, UpdateConfigMsg,
 };
@@ -288,7 +288,7 @@ fn transact_deposit(
 
     validate_proof(deps.branch(), proof_data.clone(), ext_data.clone())?;
 
-    let ext_data_fee: u128 = ext_data.fee.parse().expect("Invalid ext_fee");
+    let ext_data_fee: u128 = ext_data.fee.u128();
     let ext_amt: i128 = ext_data.ext_amount.parse().expect("Invalid ext_amount");
     let abs_ext_amt = ext_amt.unsigned_abs();
 
@@ -355,7 +355,7 @@ fn transact_deposit_wrap_native(
 
     validate_proof(deps.branch(), proof_data.clone(), ext_data.clone())?;
 
-    let ext_data_fee: u128 = ext_data.fee.parse().expect("Invalid ext_fee");
+    let ext_data_fee: u128 = ext_data.fee.u128();
     let ext_amt: i128 = ext_data.ext_amount.parse().expect("Invalid ext_amount");
     let abs_ext_amt = ext_amt.unsigned_abs();
 
@@ -421,7 +421,7 @@ fn transact_deposit_wrap_cw20(
 
     validate_proof(deps.branch(), proof_data.clone(), ext_data.clone())?;
 
-    let ext_data_fee: u128 = ext_data.fee.parse().expect("Invalid ext_fee");
+    let ext_data_fee: u128 = ext_data.fee.u128();
     let ext_amt: i128 = ext_data.ext_amount.parse().expect("Invalid ext_amount");
     let abs_ext_amt = ext_amt.unsigned_abs();
 
@@ -482,7 +482,7 @@ fn transact_withdraw(
     validate_proof(deps.branch(), proof_data.clone(), ext_data.clone())?;
 
     let vanchor = VANCHOR.load(deps.storage)?;
-    let ext_data_fee: u128 = ext_data.fee.parse().expect("Invalid ext_fee");
+    let ext_data_fee: u128 = ext_data.fee.u128();
     let ext_amt: i128 = ext_data.ext_amount.parse().expect("Invalid ext_amount");
     let abs_ext_amt = ext_amt.unsigned_abs();
 
@@ -538,7 +538,7 @@ fn transact_withdraw_unwrap(
     validate_proof(deps.branch(), proof_data.clone(), ext_data.clone())?;
 
     let vanchor = VANCHOR.load(deps.storage)?;
-    let ext_data_fee: u128 = ext_data.fee.parse().expect("Invalid ext_fee");
+    let ext_data_fee: u128 = ext_data.fee.u128();
     let ext_amt: i128 = ext_data.ext_amount.parse().expect("Invalid ext_amount");
     let abs_ext_amt = ext_amt.unsigned_abs();
 
@@ -593,7 +593,7 @@ fn validate_proof(
 ) -> Result<(), ContractError> {
     let vanchor = VANCHOR.load(deps.storage)?;
 
-    let ext_data_fee: u128 = ext_data.fee.parse().expect("Invalid ext_fee");
+    let ext_data_fee: u128 = ext_data.fee.u128();
     let ext_amt: i128 = ext_data.ext_amount.parse().expect("Invalid ext_amount");
 
     // Validation 1. Double check the number of roots.
@@ -740,10 +740,9 @@ fn wrap_native(
     deps: DepsMut,
     sender: String,
     recipient: String,
-    amount: String,
+    amount: Uint128,
     sent_funds: Vec<Coin>,
 ) -> Result<Response, ContractError> {
-    let amount = parse_string_to_uint128(amount)?;
     let vanchor = VANCHOR.load(deps.storage)?;
 
     // Validations
@@ -782,9 +781,8 @@ fn unwrap_native(
     deps: DepsMut,
     sender: String,
     recipient: String,
-    amount: String,
+    amount: Uint128,
 ) -> Result<Response, ContractError> {
-    let amount = parse_string_to_uint128(amount)?;
     let vanchor = VANCHOR.load(deps.storage)?;
 
     // Handle the "Unwrap"
@@ -848,9 +846,8 @@ fn unwrap_into_token(
     sender: String,
     recipient: String,
     token_addr: String,
-    amount: String,
+    amount: Uint128,
 ) -> Result<Response, ContractError> {
-    let amount = parse_string_to_uint128(amount)?;
     let vanchor = VANCHOR.load(deps.storage)?;
 
     // Handle the "Unwrap"

--- a/contracts/vanchor/src/state.rs
+++ b/contracts/vanchor/src/state.rs
@@ -188,6 +188,8 @@ pub struct VAnchor {
     pub min_withdraw_amt: Uint128,
     pub max_ext_amt: Uint128,
     pub max_fee: Uint128,
+    pub proposal_nonce: u32,
+    pub handler: Addr,
 }
 
 pub const VANCHOR: Item<VAnchor> = Item::new("vanchor");
@@ -196,7 +198,7 @@ pub const VANCHOR: Item<VAnchor> = Item::new("vanchor");
 pub const NULLIFIERS: Map<Vec<u8>, bool> = Map::new("used_nullifers");
 
 // "Poseidon hasher"
-pub const POSEIDON: Item<Poseidon> = Item::new("poseidon");
+pub const HASHER: Item<Poseidon> = Item::new("poseidon");
 
 // "VAnchorVerifier (2 * 2)
 pub const VERIFIER_2_2: Item<VAnchorVerifier> = Item::new("vanchor_verifier_2_2");

--- a/contracts/vanchor/src/tests.rs
+++ b/contracts/vanchor/src/tests.rs
@@ -2,9 +2,7 @@ use ark_ff::BigInteger;
 use ark_ff::PrimeField;
 use arkworks_setups::Curve;
 use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info, MockApi, MockStorage};
-use cosmwasm_std::OwnedDeps;
-use cosmwasm_std::StdError;
-use cosmwasm_std::{attr, coins, to_binary, Uint128};
+use cosmwasm_std::{attr, coins, to_binary, OwnedDeps, Uint128};
 use cw20::Cw20ReceiveMsg;
 use protocol_cosmwasm::error::ContractError;
 use sp_core::hashing::keccak_256;
@@ -537,10 +535,7 @@ fn test_vanchor_should_not_complete_transaction_if_ext_data_is_invalid() {
     };
 
     let err = execute(deps.as_mut(), mock_env(), info, withdraw_cw20_msg).unwrap_err();
-    assert_eq!(
-        err.to_string(),
-        "Generic error: Invalid ext data".to_string()
-    );
+    assert_eq!(err.to_string(), "Invalid ext data".to_string());
 }
 
 #[test]
@@ -691,10 +686,7 @@ fn test_vanchor_should_not_complete_withdraw_if_out_amount_sum_is_too_big() {
     };
 
     let err = execute(deps.as_mut(), mock_env(), info, withdraw_cw20_msg).unwrap_err();
-    assert_eq!(
-        err.to_string(),
-        "Generic error: Invalid transaction proof".to_string()
-    );
+    assert_eq!(err.to_string(), "Invalid transaction proof".to_string());
 }
 
 #[test]
@@ -845,10 +837,7 @@ fn test_vanchor_should_not_complete_withdraw_if_out_amount_sum_is_too_small() {
     };
 
     let err = execute(deps.as_mut(), mock_env(), info, withdraw_cw20_msg).unwrap_err();
-    assert_eq!(
-        err.to_string(),
-        "Generic error: Invalid transaction proof".to_string()
-    );
+    assert_eq!(err.to_string(), "Invalid transaction proof".to_string());
 }
 
 #[test]
@@ -1011,7 +1000,7 @@ fn test_vanchor_should_not_be_able_to_double_spend() {
     let err = execute(deps.as_mut(), mock_env(), info, withdraw_cw20_msg).unwrap_err();
     assert_eq!(
         err.to_string(),
-        "Generic error: Nullifier is known".to_string()
+        "Invalid nullifier that is already used".to_string()
     );
 }
 
@@ -1627,12 +1616,7 @@ fn test_vanchor_set_handler() {
         nonce: nonce + 2000,
     };
     let err = execute(deps.as_mut(), mock_env(), info, set_handler_msg).unwrap_err();
-    assert_eq!(
-        err,
-        ContractError::Std(StdError::GenericErr {
-            msg: "Invalid nonce".to_string()
-        })
-    );
+    assert_eq!(err, ContractError::InvalidNonce);
 
     // Succeed to "set handler"
     let info = mock_info(HANDLER, &[]);

--- a/contracts/vanchor/src/tests.rs
+++ b/contracts/vanchor/src/tests.rs
@@ -28,6 +28,7 @@ const CW20_ADDRESS: &str = "terra1340t6lqq6jxhm8d6gtz0hzz5jzcszvm27urkn2";
 const TRANSACTOR: &str = "terra1kejftqzx05y9rv00lw5m76csfmx7lf9se02dz4";
 const RECIPIENT: &str = "terra1kejftqzx05y9rv00lw5m76csfmx7lf9se02dz4";
 const RELAYER: &str = "terra1jrj2vh6cstqwk3pg8nkmdf0r9z0n3q3f3jk5xn";
+const HANDLER: &str = "terra1fex9f78reuwhfsnc8sun6mz8rl9zwqh03fhwf3";
 
 fn element_encoder(v: &[u8]) -> [u8; 32] {
     let mut output = [0u8; 32];
@@ -47,6 +48,7 @@ fn create_vanchor() -> OwnedDeps<MockStorage, MockApi, crate::mock_querier::Wasm
         max_ext_amt: Uint128::from(MAX_EXT_AMT),
         max_fee: Uint128::from(MAX_FEE),
         tokenwrapper_addr: CW20_ADDRESS.to_string(),
+        handler: HANDLER.to_string(),
     };
     let info = mock_info("creator", &[]);
 
@@ -85,6 +87,7 @@ fn test_vanchor_proper_initialization() {
         max_ext_amt: Uint128::from(MAX_EXT_AMT),
         max_fee: Uint128::from(MAX_FEE),
         tokenwrapper_addr: CW20_ADDRESS.to_string(),
+        handler: HANDLER.to_string(),
     };
     let info = mock_info("creator", &[]);
 

--- a/contracts/vanchor/src/tests.rs
+++ b/contracts/vanchor/src/tests.rs
@@ -168,7 +168,7 @@ fn test_vanchor_should_complete_2x2_transaction_with_deposit_cw20() {
         recipient: RECIPIENT.to_string(),
         relayer: RELAYER.to_string(),
         ext_amount: ext_amount.to_string(),
-        fee: fee.to_string(),
+        fee: Uint128::from(fee),
         encrypted_output1: element_encoder(&output1),
         encrypted_output2: element_encoder(&output2),
     };
@@ -254,7 +254,7 @@ fn test_vanchor_should_complete_2x2_transaction_with_withdraw_cw20() {
         recipient: RECIPIENT.to_string(),
         relayer: RELAYER.to_string(),
         ext_amount: ext_amount.to_string(),
-        fee: fee.to_string(),
+        fee: Uint128::from(fee),
         encrypted_output1: element_encoder(&output1),
         encrypted_output2: element_encoder(&output2),
     };
@@ -327,7 +327,7 @@ fn test_vanchor_should_complete_2x2_transaction_with_withdraw_cw20() {
         recipient: RECIPIENT.to_string(),
         relayer: RELAYER.to_string(),
         ext_amount: ext_amount.to_string(),
-        fee: fee.to_string(),
+        fee: Uint128::from(fee),
         encrypted_output1: element_encoder(&output1),
         encrypted_output2: element_encoder(&output2),
     };
@@ -409,7 +409,7 @@ fn test_vanchor_should_not_complete_transaction_if_ext_data_is_invalid() {
         recipient: RECIPIENT.to_string(),
         relayer: RELAYER.to_string(),
         ext_amount: ext_amount.to_string(),
-        fee: fee.to_string(),
+        fee: Uint128::from(fee),
         encrypted_output1: element_encoder(&output1),
         encrypted_output2: element_encoder(&output2),
     };
@@ -482,7 +482,7 @@ fn test_vanchor_should_not_complete_transaction_if_ext_data_is_invalid() {
         recipient: RECIPIENT.to_string(),
         relayer: RELAYER.to_string(),
         ext_amount: ext_amount.to_string(),
-        fee: fee.to_string(),
+        fee: Uint128::from(fee),
         encrypted_output1: element_encoder(&output1),
         encrypted_output2: element_encoder(&output2),
     };
@@ -508,7 +508,7 @@ fn test_vanchor_should_not_complete_transaction_if_ext_data_is_invalid() {
         recipient: RECIPIENT.to_string(),
         relayer: RELAYER.to_string(),
         ext_amount: ext_amount.to_string(),
-        fee: fee.to_string(),
+        fee: Uint128::from(fee),
         encrypted_output1: element_encoder(&output1),
         encrypted_output2: [0u8; 32],
     };
@@ -570,7 +570,7 @@ fn test_vanchor_should_not_complete_withdraw_if_out_amount_sum_is_too_big() {
         recipient: RECIPIENT.to_string(),
         relayer: RELAYER.to_string(),
         ext_amount: ext_amount.to_string(),
-        fee: fee.to_string(),
+        fee: Uint128::from(fee),
         encrypted_output1: element_encoder(&output1),
         encrypted_output2: element_encoder(&output2),
     };
@@ -643,7 +643,7 @@ fn test_vanchor_should_not_complete_withdraw_if_out_amount_sum_is_too_big() {
         recipient: RECIPIENT.to_string(),
         relayer: RELAYER.to_string(),
         ext_amount: ext_amount.to_string(),
-        fee: fee.to_string(),
+        fee: Uint128::from(fee),
         encrypted_output1: element_encoder(&output1),
         encrypted_output2: element_encoder(&output2),
     };
@@ -721,7 +721,7 @@ fn test_vanchor_should_not_complete_withdraw_if_out_amount_sum_is_too_small() {
         recipient: RECIPIENT.to_string(),
         relayer: RELAYER.to_string(),
         ext_amount: ext_amount.to_string(),
-        fee: fee.to_string(),
+        fee: Uint128::from(fee),
         encrypted_output1: element_encoder(&output1),
         encrypted_output2: element_encoder(&output2),
     };
@@ -794,7 +794,7 @@ fn test_vanchor_should_not_complete_withdraw_if_out_amount_sum_is_too_small() {
         recipient: RECIPIENT.to_string(),
         relayer: RELAYER.to_string(),
         ext_amount: ext_amount.to_string(),
-        fee: fee.to_string(),
+        fee: Uint128::from(fee),
         encrypted_output1: element_encoder(&output1),
         encrypted_output2: element_encoder(&output2),
     };
@@ -872,7 +872,7 @@ fn test_vanchor_should_not_be_able_to_double_spend() {
         recipient: RECIPIENT.to_string(),
         relayer: RELAYER.to_string(),
         ext_amount: ext_amount.to_string(),
-        fee: fee.to_string(),
+        fee: Uint128::from(fee),
         encrypted_output1: element_encoder(&output1),
         encrypted_output2: element_encoder(&output2),
     };
@@ -945,7 +945,7 @@ fn test_vanchor_should_not_be_able_to_double_spend() {
         recipient: RECIPIENT.to_string(),
         relayer: RELAYER.to_string(),
         ext_amount: ext_amount.to_string(),
-        fee: fee.to_string(),
+        fee: Uint128::from(fee),
         encrypted_output1: element_encoder(&output1),
         encrypted_output2: element_encoder(&output2),
     };
@@ -1036,7 +1036,7 @@ fn test_vanchor_should_complete_16x2_transaction_with_deposit_cw20() {
         recipient: RECIPIENT.to_string(),
         relayer: RELAYER.to_string(),
         ext_amount: ext_amount.to_string(),
-        fee: fee.to_string(),
+        fee: Uint128::from(fee),
         encrypted_output1: element_encoder(&output1),
         encrypted_output2: element_encoder(&output2),
     };
@@ -1122,7 +1122,7 @@ fn test_vanchor_should_complete_16x2_transaction_with_withdraw_cw20() {
         recipient: RECIPIENT.to_string(),
         relayer: RELAYER.to_string(),
         ext_amount: ext_amount.to_string(),
-        fee: fee.to_string(),
+        fee: Uint128::from(fee),
         encrypted_output1: element_encoder(&output1),
         encrypted_output2: element_encoder(&output2),
     };
@@ -1195,7 +1195,7 @@ fn test_vanchor_should_complete_16x2_transaction_with_withdraw_cw20() {
         recipient: RECIPIENT.to_string(),
         relayer: RELAYER.to_string(),
         ext_amount: ext_amount.to_string(),
-        fee: fee.to_string(),
+        fee: Uint128::from(fee),
         encrypted_output1: element_encoder(&output1),
         encrypted_output2: element_encoder(&output2),
     };
@@ -1253,7 +1253,7 @@ fn test_vanchor_wrap_native() {
 
     let info = mock_info("anyone", &coins(wrap_amt.u128(), "uusd"));
     let wrap_native_msg = ExecuteMsg::WrapNative {
-        amount: wrap_amt.to_string(),
+        amount: Uint128::from(wrap_amt),
         is_deposit: false,
     };
     let response = execute(deps.as_mut(), mock_env(), info, wrap_native_msg).unwrap();
@@ -1277,7 +1277,7 @@ fn test_vanchor_unwrap_native() {
 
     let info = mock_info("anyone", &[]);
     let unwrap_native_msg = ExecuteMsg::UnwrapNative {
-        amount: unwrap_amt.to_string(),
+        amount: unwrap_amt,
         recipient: None,
     };
     let response = execute(deps.as_mut(), mock_env(), info, unwrap_native_msg).unwrap();
@@ -1322,13 +1322,13 @@ fn test_vanchor_wrap_token() {
 fn test_vanchor_unwrap_into_token() {
     let mut deps = create_vanchor();
 
-    let unwrap_amt = "100";
+    let unwrap_amt = 100_u128;
     let recv_token = "recv_token";
 
     let info = mock_info("anyone", &[]);
     let unwrap_into_token_msg = ExecuteMsg::UnwrapIntoToken {
         token_addr: recv_token.to_string(),
-        amount: unwrap_amt.to_string(),
+        amount: Uint128::from(unwrap_amt),
         recipient: None,
     };
     let response = execute(deps.as_mut(), mock_env(), info, unwrap_into_token_msg).unwrap();
@@ -1339,7 +1339,7 @@ fn test_vanchor_unwrap_into_token() {
         vec![
             attr("method", "unwrap_into_token"),
             attr("token", recv_token),
-            attr("amount", unwrap_amt),
+            attr("amount", unwrap_amt.to_string()),
         ]
     );
 }
@@ -1376,7 +1376,7 @@ fn test_vanchor_wrap_and_deposit_cw20() {
         recipient: RECIPIENT.to_string(),
         relayer: RELAYER.to_string(),
         ext_amount: ext_amount.to_string(),
-        fee: fee.to_string(),
+        fee: Uint128::from(fee),
         encrypted_output1: element_encoder(&output1),
         encrypted_output2: element_encoder(&output2),
     };
@@ -1466,7 +1466,7 @@ fn test_vanchor_withdraw_and_unwrap_native() {
         recipient: RECIPIENT.to_string(),
         relayer: RELAYER.to_string(),
         ext_amount: ext_amount.to_string(),
-        fee: fee.to_string(),
+        fee: Uint128::from(fee),
         encrypted_output1: element_encoder(&output1),
         encrypted_output2: element_encoder(&output2),
     };
@@ -1539,7 +1539,7 @@ fn test_vanchor_withdraw_and_unwrap_native() {
         recipient: RECIPIENT.to_string(),
         relayer: RELAYER.to_string(),
         ext_amount: ext_amount.to_string(),
-        fee: fee.to_string(),
+        fee: Uint128::from(fee),
         encrypted_output1: element_encoder(&output1),
         encrypted_output2: element_encoder(&output2),
     };

--- a/contracts/vanchor/src/tests.rs
+++ b/contracts/vanchor/src/tests.rs
@@ -102,8 +102,6 @@ fn test_vanchor_update_config() {
 
     // Fail to update the config with "unauthorized" error.
     let update_config_msg = UpdateConfigMsg {
-        max_deposit_amt: Some(Uint128::from(1u128)),
-        min_withdraw_amt: Some(Uint128::from(1u128)),
         max_ext_amt: Some(Uint128::from(1u128)),
         max_fee: Some(Uint128::from(1u128)),
     };
@@ -121,8 +119,6 @@ fn test_vanchor_update_config() {
 
     // We can just call .unwrap() to assert "execute" was success
     let update_config_msg = UpdateConfigMsg {
-        max_deposit_amt: Some(Uint128::from(1u128)),
-        min_withdraw_amt: Some(Uint128::from(1u128)),
         max_ext_amt: Some(Uint128::from(1u128)),
         max_fee: Some(Uint128::from(1u128)),
     };

--- a/contracts/vanchor/tests/integration.rs
+++ b/contracts/vanchor/tests/integration.rs
@@ -23,6 +23,7 @@ const MIN_WITHDRAW_AMT: u128 = 0;
 const MAX_EXT_AMT: u128 = 20;
 const MAX_FEE: u128 = 10;
 const CW20_ADDRESS: &str = "terra1340t6lqq6jxhm8d6gtz0hzz5jzcszvm27urkn2";
+const HANDLER: &str = "terra1fex9f78reuwhfsnc8sun6mz8rl9zwqh03fhwf3";
 
 #[test]
 fn integration_test_instantiate_mixer() {
@@ -38,6 +39,7 @@ fn integration_test_instantiate_mixer() {
         max_ext_amt: Uint128::from(MAX_EXT_AMT),
         max_fee: Uint128::from(MAX_FEE),
         tokenwrapper_addr: CW20_ADDRESS.to_string(),
+        handler: HANDLER.to_string(),
     };
     let info = mock_info("creator", &[]);
     let response: Response = instantiate(&mut deps, mock_env(), info, msg).unwrap();

--- a/packages/protocol_cosmwasm/src/anchor.rs
+++ b/packages/protocol_cosmwasm/src/anchor.rs
@@ -105,29 +105,4 @@ pub struct ConfigResponse {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct EdgeInfoResponse {
-    pub src_chain_id: u64,
-    pub root: [u8; 32],
-    pub latest_leaf_index: u32,
-    pub target: [u8; 32],
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct NeighborRootInfoResponse {
-    pub neighbor_root: [u8; 32],
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct MerkleTreeInfoResponse {
-    pub levels: u32,
-    pub curr_root_index: u32,
-    pub next_index: u32,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct MerkleRootInfoResponse {
-    pub root: [u8; 32],
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct MigrateMsg {}

--- a/packages/protocol_cosmwasm/src/error.rs
+++ b/packages/protocol_cosmwasm/src/error.rs
@@ -71,6 +71,31 @@ pub enum ContractError {
     #[error("Invalid nonce")]
     InvalidNonce,
 
+    /*  ------ VAnchor errors ------ */
+    #[error("Invalid execution entry")]
+    InvalidExecutionEntry,
+
+    #[error("Invalid deposit amount")]
+    InvalidDepositAmount,
+
+    #[error("Invalid withdraw amount")]
+    InvalidWithdrawAmount,
+
+    #[error("Invalid ext data")]
+    InvalidExtData,
+
+    #[error("Invalid fee amount")]
+    InvalidFeeAmount,
+
+    #[error("Invalid ext amount")]
+    InvalidExtAmount,
+
+    #[error("Invalid public amount")]
+    InvalidPublicAmount,
+
+    #[error("Invalid transaction proof")]
+    InvalidTxProof,
+
     /*  ------ TokenWrapper errors ------ */
     // For simplicity, it just converts all the cw20_base errors to Std error.
     #[error("Invalid CW20 token address")]

--- a/packages/protocol_cosmwasm/src/structs.rs
+++ b/packages/protocol_cosmwasm/src/structs.rs
@@ -26,3 +26,28 @@ pub struct Edge {
     /// Target contract address or tree identifier
     pub target: Element,
 }
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct EdgeInfoResponse {
+    pub src_chain_id: u64,
+    pub root: [u8; 32],
+    pub latest_leaf_index: u32,
+    pub target: [u8; 32],
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct NeighborRootInfoResponse {
+    pub neighbor_root: [u8; 32],
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct MerkleTreeInfoResponse {
+    pub levels: u32,
+    pub curr_root_index: u32,
+    pub next_index: u32,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct MerkleRootInfoResponse {
+    pub root: [u8; 32],
+}

--- a/packages/protocol_cosmwasm/src/vanchor.rs
+++ b/packages/protocol_cosmwasm/src/vanchor.rs
@@ -70,14 +70,6 @@ pub enum ExecuteMsg {
         ext_data: ExtData,
     },
 
-    /// Add an edge to underlying tree
-    AddEdge {
-        src_chain_id: u64,
-        root: [u8; 32],
-        latest_leaf_index: u32,
-        target: [u8; 32],
-    },
-
     /// Update an edge for underlying tree
     UpdateEdge {
         src_chain_id: u64,

--- a/packages/protocol_cosmwasm/src/vanchor.rs
+++ b/packages/protocol_cosmwasm/src/vanchor.rs
@@ -85,6 +85,9 @@ pub enum ExecuteMsg {
         latest_leaf_index: u32,
         target: [u8; 32],
     },
+
+    /// Sets a new handler for the contract
+    SetHandler { handler: String, nonce: u32 },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/protocol_cosmwasm/src/vanchor.rs
+++ b/packages/protocol_cosmwasm/src/vanchor.rs
@@ -13,6 +13,7 @@ pub struct InstantiateMsg {
     pub min_withdraw_amt: Uint128,
     pub max_ext_amt: Uint128,
     pub max_fee: Uint128,
+    pub handler: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/protocol_cosmwasm/src/vanchor.rs
+++ b/packages/protocol_cosmwasm/src/vanchor.rs
@@ -35,7 +35,10 @@ pub enum ExecuteMsg {
 
     /// Wraps the native token to "TokenWrapper" token
     /// Send the tokens back to `tx sender` or deposit to `this` contract
-    WrapNative { amount: Uint128, is_deposit: bool },
+    WrapNative {
+        amount: Uint128,
+        is_deposit: bool,
+    },
 
     /// Unwraps the "TokenWrapper" token to native token
     /// Send the tokens back to `tx sender` or `recipient`
@@ -70,22 +73,31 @@ pub enum ExecuteMsg {
         ext_data: ExtData,
     },
 
+    /// Sets a new handler for the contract
+    SetHandler {
+        handler: String,
+        nonce: u32,
+    },
+
     /// Update an edge for underlying tree
     UpdateEdge {
         src_chain_id: u64,
         root: [u8; 32],
-        latest_leaf_index: u32,
+        latest_leaf_id: u32,
         target: [u8; 32],
     },
 
-    /// Sets a new handler for the contract
-    SetHandler { handler: String, nonce: u32 },
+    ConfigureMinimalWithdrawalLimit {
+        minimal_withdrawal_amount: Uint128,
+    },
+
+    ConfigureMaximumDepositLimit {
+        maximum_deposit_amount: Uint128,
+    },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct UpdateConfigMsg {
-    pub max_deposit_amt: Option<Uint128>,
-    pub min_withdraw_amt: Option<Uint128>,
     pub max_ext_amt: Option<Uint128>,
     pub max_fee: Option<Uint128>,
 }

--- a/packages/protocol_cosmwasm/src/vanchor.rs
+++ b/packages/protocol_cosmwasm/src/vanchor.rs
@@ -35,12 +35,12 @@ pub enum ExecuteMsg {
 
     /// Wraps the native token to "TokenWrapper" token
     /// Send the tokens back to `tx sender` or deposit to `this` contract
-    WrapNative { amount: String, is_deposit: bool },
+    WrapNative { amount: Uint128, is_deposit: bool },
 
     /// Unwraps the "TokenWrapper" token to native token
     /// Send the tokens back to `tx sender` or `recipient`
     UnwrapNative {
-        amount: String,
+        amount: Uint128,
         recipient: Option<String>,
     },
 
@@ -49,7 +49,7 @@ pub enum ExecuteMsg {
     /// Send the tokens back to `tx sender` or `recipient`
     UnwrapIntoToken {
         token_addr: String,
-        amount: String,
+        amount: Uint128,
         recipient: Option<String>,
     },
 
@@ -146,8 +146,8 @@ impl ProofData {
 pub struct ExtData {
     pub recipient: String,
     pub relayer: String,
-    pub ext_amount: String,
-    pub fee: String,
+    pub ext_amount: String, // Still `String` since represents `i128` value
+    pub fee: Uint128,
     pub encrypted_output1: [u8; 32],
     pub encrypted_output2: [u8; 32],
 }

--- a/packages/protocol_cosmwasm/src/vanchor.rs
+++ b/packages/protocol_cosmwasm/src/vanchor.rs
@@ -167,5 +167,24 @@ pub struct ExtData {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
-    // TODO
+    Config {},
+    EdgeInfo { id: u64 },
+    NeighborRootInfo { chain_id: u64, id: u32 },
+    MerkleTreeInfo {},
+    MerkleRootInfo { id: u32 },
 }
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct ConfigResponse {
+    pub handler: String,
+    pub proposal_nonce: u32,
+    pub tokenwrapper_addr: String,
+    pub chain_id: u64,
+    pub max_deposit_amt: String,
+    pub min_withdraw_amt: String,
+    pub max_ext_amt: String,
+    pub max_fee: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct MigrateMsg {}


### PR DESCRIPTION
Summary of changes
Changes introduced in this pull request

Update the `vanchor` contract so that its entries match the `LinkableAnchor` interface

     - Add the `handler` & `proposal_nonce` fields to the `vanchor` contract state
     - Add new execution entry `set_handler` to update the `handler` state in `vanchor` contract
     - Add new execution entries `configure_maximum_deposit_limit` & `configure_minimal_withdraw_limit`
     - Merge the `add_edge` execution entry to `update_edge` entry in `vanchor` contract
     - Done some re-typing, renaming the params
     - Implement the `query` & `migrate` entries

Reference issue to close (if applicable)
Closes