### PR TITLE
Update the `fee_percentage` in `token_wrapper` contract

### DIFF
--- a/contracts/tokenwrapper/src/state.rs
+++ b/contracts/tokenwrapper/src/state.rs
@@ -1,7 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use cosmwasm_std::{Addr, Decimal, Uint128};
+use cosmwasm_std::{Addr, Uint128};
 use cw_storage_plus::{Item, Map};
 
 /// Config
@@ -11,7 +11,7 @@ pub struct Config {
     pub governor: Addr,
     pub native_token_denom: String,
     pub fee_recipient: Addr,
-    pub fee_percentage: Decimal,
+    pub fee_percentage: u8,
     pub is_native_allowed: bool,
     pub wrapping_limit: Uint128,
     pub proposal_nonce: u64,

--- a/contracts/tokenwrapper/src/tests.rs
+++ b/contracts/tokenwrapper/src/tests.rs
@@ -16,7 +16,7 @@ const NAME: &str = "Webb-WRAP";
 const SYMBOL: &str = "WWRP";
 const DECIMALS: u8 = 6;
 const FEE_RECIPIENT: &str = "terra1qca9hs2qk2w29gqduaq9k720k9293qt7q8nszl";
-const FEE_PERCENTAGE: &str = "1";
+const FEE_PERCENTAGE: u8 = 1_u8;
 const NATIVE_TOKEN_DENOM: &str = "uusd";
 const CW20_TOKEN: &str = "cw20_token";
 const WRAPPING_LIMIT: u128 = 5000000;
@@ -32,7 +32,7 @@ fn init_tokenwrapper(coins: Vec<Coin>) -> OwnedDeps<MockStorage, MockApi, MockQu
         decimals: DECIMALS,
         governor: None,
         fee_recipient: FEE_RECIPIENT.to_string(),
-        fee_percentage: FEE_PERCENTAGE.to_string(),
+        fee_percentage: FEE_PERCENTAGE,
         native_token_denom: NATIVE_TOKEN_DENOM.to_string(),
         is_native_allowed: IS_NATIVE_ALLOWED,
         wrapping_limit: Uint128::from(WRAPPING_LIMIT),
@@ -54,7 +54,7 @@ fn proper_initialization() {
         decimals: DECIMALS,
         governor: None,
         fee_recipient: FEE_RECIPIENT.to_string(),
-        fee_percentage: FEE_PERCENTAGE.to_string(),
+        fee_percentage: FEE_PERCENTAGE,
         native_token_denom: NATIVE_TOKEN_DENOM.to_string(),
         is_native_allowed: IS_NATIVE_ALLOWED,
         wrapping_limit: Uint128::from(WRAPPING_LIMIT),
@@ -82,7 +82,7 @@ fn proper_initialization() {
         NATIVE_TOKEN_DENOM.to_string()
     );
     assert_eq!(config_response.fee_recipient, FEE_RECIPIENT.to_string());
-    assert_eq!(config_response.fee_percentage, "0.01".to_string());
+    assert_eq!(config_response.fee_percentage, "1".to_string());
 }
 
 #[test]

--- a/packages/protocol_cosmwasm/src/token_wrapper.rs
+++ b/packages/protocol_cosmwasm/src/token_wrapper.rs
@@ -3,6 +3,7 @@ use cw20::{Cw20ReceiveMsg, Expiration};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+pub const WRAP_FEE_CALC_DENOMINATOR: u8 = 100_u8;
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct InstantiateMsg {
     /// name of the Wrapping target token
@@ -18,7 +19,7 @@ pub struct InstantiateMsg {
     /// addr of fee recipient
     pub fee_recipient: String,
     /// fee_percentage( 0 ~ 100 )
-    pub fee_percentage: String,
+    pub fee_percentage: u8,
     /// native token denom string to be wrapped
     pub native_token_denom: String,
     /// flag of is_native_allowed
@@ -145,7 +146,7 @@ pub struct UpdateConfigMsg {
     pub governor: Option<String>,
     pub is_native_allowed: Option<bool>,
     pub wrapping_limit: Option<Uint128>,
-    pub fee_percentage: Option<String>,
+    pub fee_percentage: Option<u8>,
     pub fee_recipient: Option<String>,
 }
 

--- a/test-scripts/src/processes/tests/tokenWrapper.ts
+++ b/test-scripts/src/processes/tests/tokenWrapper.ts
@@ -30,7 +30,7 @@ export async function testTokenWrapperInitialize(
     expect(result.governor == localjuno.addresses.wallet1).to.be.ok;
     expect(result.native_token_denom == localjuno.contractsConsts.nativeTokenDenom).to.be.ok;
     expect(result.fee_recipient == localjuno.addresses.wallet2).to.be.ok;
-    expect(result.fee_percentage == (parseInt(localjuno.contractsConsts.feePercentage) / 100).toString()).to.be.ok;
+    expect(result.fee_percentage == localjuno.contractsConsts.feePercentage.toString()).to.be.ok;
     expect(result.is_native_allowed == (localjuno.contractsConsts.isNativeAllowed == 1).toString()).to.be.ok;
     expect(result.wrapping_limit == localjuno.contractsConsts.tokenWrapperWrappingLimit).to.be.ok;
     expect(result.proposal_nonce == "1").to.be.ok;


### PR DESCRIPTION
Summary of changes
Changes introduced in this pull request

- Update the data type of `fee_percentage` from `String` to `u8`(0 ~ 100)
- Add more validations for `fee_percentage` value
- Introduce the constant `WRAP_FEE_CALC_DENOMINATOR`(100_u8) for new changes

Reference issue to close (if applicable)
Closes